### PR TITLE
Add folder management, rename, QR, and bulk file actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
 # FlashShare
+
+A lightweight Flask app for sharing files with a drag-and-drop interface and glassmorphism UI.
+
+## Features
+- Drag-and-drop uploads with a progress bar
+- Image thumbnails and generic icons for other files
+- Glassmorphism styling
+- Supports files up to 50 MB
+- Delete and download files
+
+## Local Development
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the application:
+   ```bash
+   python app.py
+   ```
+   The server starts at `http://localhost:5050`.
+
+## Deployment
+### Replit
+1. Create a new Replit and import this repository.
+2. Install dependencies automatically or run `pip install -r requirements.txt`.
+3. Set the Run command to `python app.py`.
+4. Replit will provide a public URL to preview the app.
+
+### Render
+1. Push this repository to GitHub.
+2. Create a new **Web Service** on Render and connect the repo.
+3. Build command: `pip install -r requirements.txt`
+4. Start command: `gunicorn app:app`
+5. Render will deploy the service and supply a public URL.
+
+Uploads are saved to the `uploads/` directory on the server.

--- a/app.py
+++ b/app.py
@@ -1,67 +1,194 @@
 import os
+import io
+import shutil
+import zipfile
 from datetime import datetime
-from flask import Flask, render_template, request, redirect, url_for, send_from_directory, flash, jsonify
+from flask import (
+    Flask,
+    render_template,
+    request,
+    send_from_directory,
+    flash,
+    jsonify,
+    send_file,
+    abort,
+)
+from werkzeug.utils import secure_filename
+from werkzeug.exceptions import RequestEntityTooLarge
 
 UPLOAD_FOLDER = 'uploads'
-ALLOWED_EXTENSIONS = set(['txt', 'pdf', 'png', 'jpg', 'jpeg', 'gif', 'zip', 'mp4', 'mp3', 'csv', 'xlsx', 'docx'])
+ALLOWED_EXTENSIONS = {
+    'txt', 'pdf', 'png', 'jpg', 'jpeg', 'gif', 'zip',
+    'mp4', 'mp3', 'csv', 'xlsx', 'docx'
+}
+IMAGE_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif'}
 
 app = Flask(__name__)
 app.secret_key = "file-sharing-secret-key"
 app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
+app.config['MAX_CONTENT_LENGTH'] = 50 * 1024 * 1024  # 50MB limit
 
 if not os.path.exists(UPLOAD_FOLDER):
     os.makedirs(UPLOAD_FOLDER)
 
+
+def safe_path(*paths):
+    base = os.path.abspath(app.config['UPLOAD_FOLDER'])
+    final = os.path.abspath(os.path.join(base, *paths))
+    if os.path.commonpath([final, base]) != base:
+        raise ValueError("Unsafe path")
+    return final
+
 def allowed_file(filename):
     return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
 
-def get_files():
-    files = []
-    for filename in os.listdir(UPLOAD_FOLDER):
-        path = os.path.join(UPLOAD_FOLDER, filename)
-        stat = os.stat(path)
-        files.append({
-            'name': filename,
+def get_files(path=""):
+    directory = safe_path(path)
+    entries = []
+    for name in os.listdir(directory):
+        full = os.path.join(directory, name)
+        rel_path = os.path.join(path, name) if path else name
+        stat = os.stat(full)
+        is_folder = os.path.isdir(full)
+        extension = name.rsplit('.', 1)[1].lower() if '.' in name else ''
+        entries.append({
+            'name': name,
+            'path': rel_path.replace("\\", "/"),
             'size': stat.st_size,
             'date': datetime.fromtimestamp(stat.st_ctime).strftime("%Y-%m-%d %H:%M"),
+            'is_image': extension in IMAGE_EXTENSIONS,
+            'is_folder': is_folder,
         })
-    files.sort(key=lambda f: f['date'], reverse=True)
-    return files
+    entries.sort(key=lambda f: (not f['is_folder'], f['name'].lower()))
+    return entries
 
-@app.route('/', methods=['GET', 'POST'])
-def index():
-    if request.method == 'POST':
-        if 'file' not in request.files:
-            flash('No file part', 'danger')
-            return redirect(request.url)
-        file = request.files['file']
-        if file.filename == '':
-            flash('No selected file', 'danger')
-            return redirect(request.url)
-        if file and allowed_file(file.filename):
-            filename = file.filename
-            file.save(os.path.join(app.config['UPLOAD_FOLDER'], filename))
-            flash(f'Uploaded {filename} successfully!', 'success')
-            return redirect(url_for('index'))
-        else:
-            flash('File type not allowed.', 'danger')
-            return redirect(request.url)
-    files = get_files()
-    return render_template('index.html', files=files)
+@app.route('/', defaults={'path': ''})
+@app.route('/<path:path>')
+def index(path):
+    files = get_files(path)
+    breadcrumbs = []
+    if path:
+        parts = path.split('/')
+        accum = ''
+        for part in parts:
+            accum = os.path.join(accum, part) if accum else part
+            breadcrumbs.append({'name': part, 'path': accum.replace("\\", "/")})
+    return render_template('index.html', files=files, path=path, breadcrumbs=breadcrumbs)
 
-@app.route('/uploads/<filename>')
+
+@app.route('/upload', methods=['POST'])
+def upload():
+    path = request.args.get('path', '')
+    if 'file' not in request.files:
+        return jsonify({'success': False, 'error': 'No file part'}), 400
+    file = request.files['file']
+    if file.filename == '':
+        return jsonify({'success': False, 'error': 'No selected file'}), 400
+    if file and allowed_file(file.filename):
+        filename = secure_filename(file.filename)
+        dest = safe_path(path, filename)
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        file.save(dest)
+        return jsonify({'success': True, 'filename': filename})
+    return jsonify({'success': False, 'error': 'File type not allowed'}), 400
+
+
+@app.errorhandler(RequestEntityTooLarge)
+def file_too_large(e):
+    return jsonify({'success': False, 'error': 'File too large (max 50MB)'}), 413
+
+@app.route('/uploads/<path:filename>')
 def uploaded_file(filename):
     return send_from_directory(app.config['UPLOAD_FOLDER'], filename)
 
-@app.route('/delete/<filename>', methods=['POST'])
-def delete_file(filename):
-    path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+@app.route('/delete/<path:filepath>', methods=['POST'])
+def delete_file(filepath):
+    try:
+        path = safe_path(filepath)
+    except ValueError:
+        return jsonify({'success': False}), 400
+    if os.path.isdir(path):
+        shutil.rmtree(path, ignore_errors=True)
+        flash(f"Deleted {filepath}.", "success")
+        return jsonify({'success': True})
     if os.path.exists(path):
         os.remove(path)
-        flash(f"Deleted {filename}.", "success")
+        flash(f"Deleted {filepath}.", "success")
         return jsonify({'success': True})
     flash("File not found.", "danger")
     return jsonify({'success': False}), 404
+
+
+@app.route('/rename/<path:filepath>', methods=['POST'])
+def rename_file(filepath):
+    data = request.get_json() or {}
+    new_name = secure_filename(data.get('new_name', ''))
+    if not new_name:
+        return jsonify({'success': False, 'error': 'Invalid name'}), 400
+    directory = os.path.dirname(filepath)
+    try:
+        src = safe_path(filepath)
+        dest = safe_path(directory, new_name)
+    except ValueError:
+        return jsonify({'success': False}), 400
+    if os.path.exists(src):
+        os.rename(src, dest)
+        return jsonify({'success': True})
+    return jsonify({'success': False, 'error': 'Not found'}), 404
+
+
+@app.route('/create_folder', methods=['POST'])
+def create_folder():
+    data = request.get_json() or {}
+    path = data.get('path', '')
+    name = secure_filename(data.get('folder_name', ''))
+    if not name:
+        return jsonify({'success': False, 'error': 'Invalid name'}), 400
+    try:
+        folder_path = safe_path(path, name)
+    except ValueError:
+        return jsonify({'success': False}), 400
+    if os.path.exists(folder_path):
+        return jsonify({'success': False, 'error': 'Exists'}), 400
+    os.makedirs(folder_path)
+    return jsonify({'success': True})
+
+
+@app.route('/bulk_delete', methods=['POST'])
+def bulk_delete():
+    paths = request.get_json().get('paths', [])
+    for rel in paths:
+        try:
+            target = safe_path(rel)
+        except ValueError:
+            continue
+        if os.path.isdir(target):
+            shutil.rmtree(target, ignore_errors=True)
+        elif os.path.exists(target):
+            os.remove(target)
+    return jsonify({'success': True})
+
+
+@app.route('/bulk_download', methods=['POST'])
+def bulk_download():
+    paths = request.get_json().get('paths', [])
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w') as zf:
+        for rel in paths:
+            try:
+                target = safe_path(rel)
+            except ValueError:
+                continue
+            if os.path.isdir(target):
+                for root, dirs, files in os.walk(target):
+                    for f in files:
+                        full = os.path.join(root, f)
+                        arcname = os.path.relpath(full, app.config['UPLOAD_FOLDER'])
+                        zf.write(full, arcname)
+            elif os.path.exists(target):
+                zf.write(target, rel)
+    buf.seek(0)
+    return send_file(buf, mimetype='application/zip', as_attachment=True, download_name='files.zip')
 
 if __name__ == '__main__':
     app.run(host="0.0.0.0", port=5050, debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask>=2.2
+gunicorn>=21.2
 

--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,195 @@
+function postJSON(url, data) {
+  return fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  }).then(res => res.json());
+}
+
+function showAlert(msg, type = 'danger') {
+  const container = document.querySelector('.container');
+  if (!container) return;
+  const div = document.createElement('div');
+  div.className = `alert alert-${type} alert-dismissible fade`;
+  div.role = 'alert';
+  div.innerHTML = `${msg}<button type="button" class="btn-close" data-bs-dismiss="alert"></button>`;
+  container.prepend(div);
+  new bootstrap.Alert(div);
+  requestAnimationFrame(() => div.classList.add('show'));
+}
+
+let deletePaths = [];
+const confirmModalEl = document.getElementById('confirmModal');
+const confirmMessage = document.getElementById('confirmMessage');
+const confirmOkBtn = document.getElementById('confirmOkBtn');
+const confirmModal = confirmModalEl ? new bootstrap.Modal(confirmModalEl) : null;
+
+if (confirmOkBtn) {
+  confirmOkBtn.onclick = function () {
+    if (!deletePaths.length) return;
+    const paths = deletePaths.slice();
+    if (paths.length > 1) {
+      postJSON('/bulk_delete', { paths }).then(() => location.reload());
+    } else {
+      fetch('/delete/' + encodeURIComponent(paths[0]), { method: 'POST' })
+        .then(res => res.json())
+        .then(() => location.reload());
+    }
+  };
+}
+
+document.querySelectorAll('.delete-btn').forEach(btn => {
+  btn.onclick = function () {
+    deletePaths = [this.dataset.path];
+    if (confirmMessage) confirmMessage.textContent = 'Delete "' + this.dataset.path.split('/').pop() + '"?';
+    if (confirmModal) confirmModal.show();
+  };
+});
+
+let renamePath = null;
+const renameModalEl = document.getElementById('renameModal');
+const renameModal = renameModalEl ? new bootstrap.Modal(renameModalEl) : null;
+const renameInput = document.getElementById('renameInput');
+const renameSaveBtn = document.getElementById('renameSaveBtn');
+
+document.querySelectorAll('.rename-btn').forEach(btn => {
+  btn.onclick = function () {
+    renamePath = this.dataset.path;
+    if (renameInput) renameInput.value = renamePath.split('/').pop();
+    if (renameModal) renameModal.show();
+  };
+});
+
+if (renameSaveBtn) {
+  renameSaveBtn.onclick = function () {
+    const newName = renameInput.value.trim();
+    if (!newName) return;
+    fetch('/rename/' + encodeURIComponent(renamePath), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ new_name: newName })
+    }).then(res => res.json()).then(d => {
+      if (d.success) location.reload();
+      else showAlert('Rename failed');
+    });
+  };
+}
+
+document.querySelectorAll('.qr-btn').forEach(btn => {
+  btn.onclick = function () {
+    const url = this.dataset.url;
+    const container = document.getElementById('qrContainer');
+    if (!container) return;
+    container.innerHTML = '';
+    new QRCode(container, url);
+    if (typeof bootstrap !== 'undefined') {
+      new bootstrap.Modal(document.getElementById('qrModal')).show();
+    }
+  };
+});
+
+const dropZone = document.getElementById('dropZone');
+const fileInput = document.getElementById('fileInput');
+const progress = document.getElementById('uploadProgress');
+const progressBar = progress ? progress.querySelector('.progress-bar') : null;
+
+function handleFiles(files) {
+  if (!files || !files.length) return;
+  uploadFile(files[0]);
+}
+
+function uploadFile(file) {
+  const formData = new FormData();
+  formData.append('file', file);
+  const xhr = new XMLHttpRequest();
+  xhr.open('POST', '/upload?path=' + encodeURIComponent(CURRENT_PATH));
+  xhr.upload.addEventListener('progress', (e) => {
+    if (e.lengthComputable && progress && progressBar) {
+      progress.classList.remove('d-none');
+      const percent = (e.loaded / e.total) * 100;
+      progressBar.style.width = percent + '%';
+    }
+  });
+  xhr.onload = () => {
+    if (progress && progressBar) {
+      progress.classList.add('d-none');
+      progressBar.style.width = '0%';
+    }
+    if (xhr.status === 200) {
+      location.reload();
+    } else {
+      showAlert('Upload failed');
+    }
+  };
+  xhr.send(formData);
+}
+
+if (dropZone && fileInput) {
+  dropZone.addEventListener('click', () => fileInput.click());
+  dropZone.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    dropZone.classList.add('dragover');
+  });
+  dropZone.addEventListener('dragleave', () => dropZone.classList.remove('dragover'));
+  dropZone.addEventListener('drop', (e) => {
+    e.preventDefault();
+    dropZone.classList.remove('dragover');
+    handleFiles(e.dataTransfer.files);
+  });
+  fileInput.addEventListener('change', () => handleFiles(fileInput.files));
+}
+
+const folderModalEl = document.getElementById('folderModal');
+const folderModal = folderModalEl ? new bootstrap.Modal(folderModalEl) : null;
+const folderNameInput = document.getElementById('folderNameInput');
+const folderCreateBtn = document.getElementById('folderCreateBtn');
+
+const newFolderBtn = document.getElementById('newFolderBtn');
+if (newFolderBtn && folderModal) {
+  newFolderBtn.onclick = function () {
+    if (folderNameInput) folderNameInput.value = '';
+    folderModal.show();
+  };
+}
+
+if (folderCreateBtn) {
+  folderCreateBtn.onclick = function () {
+    const name = folderNameInput.value.trim();
+    if (!name) return;
+    postJSON('/create_folder', { path: CURRENT_PATH, folder_name: name })
+      .then(d => { if (d.success) location.reload(); else showAlert('Failed to create folder'); });
+  };
+}
+
+const bulkDeleteBtn = document.getElementById('bulkDeleteBtn');
+if (bulkDeleteBtn) {
+  bulkDeleteBtn.onclick = function () {
+    const selected = Array.from(document.querySelectorAll('.select-box:checked')).map(cb => cb.value);
+    if (!selected.length) return;
+    deletePaths = selected;
+    if (confirmMessage) confirmMessage.textContent = 'Delete selected items?';
+    if (confirmModal) confirmModal.show();
+  };
+}
+
+const bulkDownloadBtn = document.getElementById('bulkDownloadBtn');
+if (bulkDownloadBtn) {
+  bulkDownloadBtn.onclick = function () {
+    const selected = Array.from(document.querySelectorAll('.select-box:checked')).map(cb => cb.value);
+    if (!selected.length) return;
+    fetch('/bulk_download', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ paths: selected })
+    }).then(res => res.blob()).then(blob => {
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'files.zip';
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    });
+  };
+}

--- a/static/style.css
+++ b/static/style.css
@@ -1,21 +1,65 @@
 body {
     background: linear-gradient(135deg, #1f1c2c 0%, #928dab 100%);
     min-height: 100vh;
+    color: #fff;
 }
 .card {
     border-radius: 1rem;
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.3);
 }
 .text-gradient {
     background: linear-gradient(90deg, #7f53ac, #647dee);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
 }
+.upload-area {
+    border: 2px dashed rgba(255, 255, 255, 0.4);
+    padding: 2rem;
+    text-align: center;
+    cursor: pointer;
+    border-radius: 1rem;
+    color: #fff;
+    background: rgba(255, 255, 255, 0.1);
+}
+.upload-area.dragover {
+    background: rgba(255, 255, 255, 0.2);
+}
 .file-row .file-icon {
     font-size: 1.5em;
     vertical-align: middle;
 }
+.thumb {
+    width: 40px;
+    height: 40px;
+    object-fit: cover;
+    border-radius: 0.25rem;
+}
+.list-group-item {
+    background: rgba(255, 255, 255, 0.05);
+    color: #fff;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
 .btn-primary {
     background: linear-gradient(90deg, #647dee, #7f53ac);
     border: none;
+}
+
+/* tighter rows */
+.file-row {
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
+}
+
+/* small round icon buttons */
+.btn-icon {
+    width: 32px;
+    height: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    padding: 0;
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,8 +4,9 @@
     <meta charset="UTF-8">
     <title>FlashShare – File Sharing App</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="{{ url_for('static', filename='style.css') }}" rel="stylesheet">
+      <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+      <link href="{{ url_for('static', filename='style.css') }}" rel="stylesheet">
 </head>
 <body>
 <div class="container py-4">
@@ -20,35 +21,74 @@
       {% endif %}
     {% endwith %}
 
+    <nav aria-label="breadcrumb" class="mb-3">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ url_for('index') }}">Home</a></li>
+        {% for crumb in breadcrumbs %}
+          {% if loop.last %}
+            <li class="breadcrumb-item active" aria-current="page">{{ crumb.name }}</li>
+          {% else %}
+            <li class="breadcrumb-item"><a href="{{ url_for('index', path=crumb.path) }}">{{ crumb.name }}</a></li>
+          {% endif %}
+        {% endfor %}
+      </ol>
+    </nav>
+
     <!-- Upload Card -->
     <div class="card shadow-lg mb-4">
       <div class="card-body">
-        <form action="" method="post" enctype="multipart/form-data" id="uploadForm">
-          <div class="mb-3">
-            <input class="form-control" type="file" name="file" id="fileInput" required>
+        <form enctype="multipart/form-data" id="uploadForm">
+          <div id="dropZone" class="upload-area mb-3">
+            Drag & drop a file here or click to select
+            <input type="file" name="file" id="fileInput" hidden>
           </div>
-          <button class="btn btn-primary px-4" type="submit">Upload</button>
+          <div class="progress d-none" id="uploadProgress">
+            <div class="progress-bar" role="progressbar"></div>
+          </div>
         </form>
       </div>
     </div>
 
     <!-- File List -->
     <div class="card shadow-lg">
-      <div class="card-header fw-bold">Files</div>
+        <div class="card-header d-flex justify-content-between align-items-center fw-bold">
+          Files
+          <div class="btn-group btn-group-sm">
+            <button class="btn btn-primary" id="newFolderBtn"><i class="fa-solid fa-folder-plus me-1"></i>New Folder</button>
+            <button class="btn btn-outline-danger" id="bulkDeleteBtn"><i class="fa-solid fa-trash me-1"></i>Delete selected</button>
+            <button class="btn btn-outline-success" id="bulkDownloadBtn"><i class="fa-solid fa-download me-1"></i>Download selected</button>
+          </div>
+        </div>
       <ul class="list-group list-group-flush" id="fileList">
         {% for file in files %}
-          <li class="list-group-item d-flex align-items-center justify-content-between file-row">
-            <div>
-              <span class="file-icon me-2">📄</span>
-              <span class="fw-semibold">{{ file.name }}</span>
-              <span class="badge bg-secondary ms-2">{{ (file.size/1024)|round(1) }} KB</span>
-              <small class="text-muted ms-3">{{ file.date }}</small>
-            </div>
-            <div>
-              <a href="{{ url_for('uploaded_file', filename=file.name) }}" class="btn btn-outline-success btn-sm" download>Download</a>
-              <button class="btn btn-outline-danger btn-sm ms-2 delete-btn" data-filename="{{ file.name }}">Delete</button>
-            </div>
-          </li>
+            <li class="list-group-item d-flex align-items-center justify-content-between file-row">
+              <div class="d-flex align-items-center flex-grow-1">
+                <input type="checkbox" class="form-check-input me-2 select-box" value="{{ file.path }}">
+                {% if file.is_folder %}
+                  <span class="file-icon me-2">📁</span>
+                  <a href="{{ url_for('index', path=file.path) }}" class="text-decoration-none text-white flex-grow-1">{{ file.name }}</a>
+                {% else %}
+                  {% if file.is_image %}
+                    <img src="{{ url_for('uploaded_file', filename=file.path) }}" class="thumb me-2" alt="thumbnail">
+                  {% else %}
+                    <span class="file-icon me-2">📄</span>
+                  {% endif %}
+                  <div class="flex-grow-1">
+                    <span class="fw-semibold">{{ file.name }}</span>
+                    <span class="badge bg-secondary ms-2">{{ (file.size/1024)|round(1) }} KB</span>
+                    <small class="text-muted ms-3">{{ file.date }}</small>
+                  </div>
+                {% endif %}
+              </div>
+              <div class="btn-group btn-group-sm ms-2">
+                {% if not file.is_folder %}
+                  <button class="btn btn-outline-secondary btn-icon qr-btn" data-url="{{ url_for('uploaded_file', filename=file.path, _external=True) }}"><i class="fa-solid fa-qrcode"></i></button>
+                  <a href="{{ url_for('uploaded_file', filename=file.path) }}" class="btn btn-outline-success btn-icon" download><i class="fa-solid fa-download"></i></a>
+                {% endif %}
+                <button class="btn btn-outline-primary btn-icon rename-btn" data-path="{{ file.path }}"><i class="fa-solid fa-pen"></i></button>
+                <button class="btn btn-outline-danger btn-icon delete-btn" data-path="{{ file.path }}"><i class="fa-solid fa-trash"></i></button>
+              </div>
+            </li>
         {% else %}
           <li class="list-group-item text-muted">No files uploaded yet.</li>
         {% endfor %}
@@ -57,17 +97,79 @@
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-<script>
-document.querySelectorAll('.delete-btn').forEach(btn => {
-    btn.onclick = function() {
-        if (confirm('Delete "' + this.dataset.filename + '"?')) {
-            fetch('/delete/' + encodeURIComponent(this.dataset.filename), {method:'POST'})
-            .then(res => res.json())
-            .then(data => location.reload());
-        }
-    }
-});
-</script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
+<script>const CURRENT_PATH = "{{ path }}";</script>
+  <script src="{{ url_for('static', filename='app.js') }}"></script>
+
+  <!-- QR Modal -->
+  <div class="modal fade" id="qrModal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">QR Code</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body text-center">
+        <div id="qrContainer"></div>
+      </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Rename Modal -->
+  <div class="modal fade" id="renameModal" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Rename</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <input type="text" class="form-control" id="renameInput">
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="button" class="btn btn-primary" id="renameSaveBtn">Save</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- New Folder Modal -->
+  <div class="modal fade" id="folderModal" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">New Folder</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <input type="text" class="form-control" id="folderNameInput" placeholder="Folder name">
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="button" class="btn btn-primary" id="folderCreateBtn">Create</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Confirm Modal -->
+  <div class="modal fade" id="confirmModal" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Confirm</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body" id="confirmMessage"></div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="button" class="btn btn-danger" id="confirmOkBtn">Delete</button>
+        </div>
+      </div>
+    </div>
+  </div>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- Group action buttons with Bootstrap icons and colors
- Switch rename and new-folder prompts to Bootstrap modals and add delete confirmations
- Introduce rounded icon buttons and tighter file rows for a modern feel
- Enable rename option for folders

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6895e6a478648326a58ee2fa249a0a1c